### PR TITLE
fix git command for default branch

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -247,7 +247,7 @@ def github_setup(privacy: str, remote: str = "origin", default_branch: str | Non
 
     if not default_branch:
         stdout = call(
-            "git config --global init.defaultBranch", text=True, stdout=subprocess.PIPE
+            "git config --global init.defaultBranch main", text=True, stdout=subprocess.PIPE
         ).stdout
 
         if isinstance(stdout, bytes):


### PR DESCRIPTION
previous command "git config --global init.defaultBranch" is invalid. I changed it to "git config --global init.defaultBranch main" so the default is set explicitly to main.