### PR TITLE
Set upstream properly

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -258,7 +258,8 @@ def github_setup(privacy: str, remote: str = "origin", default_branch: str | Non
         default_branch = default_branch or "master"
 
     try:
-        call(f"git branch --set-upstream-to={remote} {default_branch}")
+        call("git config branch.master.remote origin")
+        call("git config branch.master.merge refs/heads/master")
     except subprocess.CalledProcessError as e:
         logger.error(f"Error setting upstream to {default_branch}: {e}")
 


### PR DESCRIPTION
`git branch --set-upstream-to origin/master master` fails if there is no existing remote branch to track.

This PR modifies the local config for both the remote and branch and fixes the problem noticed in #4. Thanks @polly-code.